### PR TITLE
Implement filter panel

### DIFF
--- a/calculosmercado.js
+++ b/calculosmercado.js
@@ -152,7 +152,9 @@ function updateSidebarStats() {
   }
 
   console.groupEnd();
-} 
+  // Exponer para que otros scripts actualicen los cálculos
+  window.updateSidebarStats = updateSidebarStats;
+}
 
     // 6) enganchar eventos
     map.on('moveend zoomend', updateSidebarStats);

--- a/filtros.js
+++ b/filtros.js
@@ -1,0 +1,53 @@
+// Manejo del panel de filtros y filtrado de ofertas
+document.addEventListener('DOMContentLoaded', () => {
+  const btnAplicar = document.getElementById('aplicarFiltros');
+  if (!btnAplicar) return;
+
+  btnAplicar.addEventListener('click', () => {
+    if (!window.ofertaLayers || !window.ofertasLayer) return;
+
+    const entSel = document.getElementById('filtro-entidad').value.toLowerCase();
+    const tiempoSel = document.getElementById('filtro-tiempo').value;
+    const precioMin = parseFloat(document.getElementById('precio-min').value);
+    const precioMax = parseFloat(document.getElementById('precio-max').value);
+    const areaMin = parseFloat(document.getElementById('area-min').value);
+    const areaMax = parseFloat(document.getElementById('area-max').value);
+
+    const ahora = Date.now();
+
+    // Quitar todas las capas actuales
+    window.ofertasLayer.clearLayers();
+
+    window.ofertaLayers.forEach(({ layer, properties }) => {
+      let ok = true;
+
+      if (entSel && properties['Tipo de Inmueble'] &&
+          properties['Tipo de Inmueble'].toLowerCase() !== entSel) {
+        ok = false;
+      }
+
+      if (ok && tiempoSel) {
+        const fecha = new Date(properties['Fecha del Registro']);
+        const diffMes = (ahora - fecha.getTime()) / (1000 * 60 * 60 * 24 * 30);
+        if (tiempoSel.startsWith('1') && (diffMes < 1 || diffMes > 6)) ok = false;
+        else if (tiempoSel.startsWith('6') && (diffMes <= 6 || diffMes > 12)) ok = false;
+        else if (tiempoSel.startsWith('Mayor') && diffMes <= 12) ok = false;
+      }
+
+      const valor = parseFloat(properties['Valor por unidad (COP)']);
+      if (ok && !isNaN(precioMin) && valor < precioMin) ok = false;
+      if (ok && !isNaN(precioMax) && valor > precioMax) ok = false;
+
+      const area = parseFloat(properties['Área Hec']);
+      if (ok && !isNaN(areaMin) && area < areaMin) ok = false;
+      if (ok && !isNaN(areaMax) && area > areaMax) ok = false;
+
+      if (ok) {
+        window.ofertasLayer.addLayer(layer);
+      }
+    });
+
+    if (window.updateSidebarStats) window.updateSidebarStats();
+  });
+});
+

--- a/index.html
+++ b/index.html
@@ -184,7 +184,7 @@
   <form id="form-filtros" class="space-y-4 text-sm">
     <div>
       <label class="block font-semibold text-gray-700">Tiempo</label>
-      <select class="w-full border border-gray-300 p-2 rounded">
+      <select id="filtro-tiempo" class="w-full border border-gray-300 p-2 rounded">
         <option>1 - 6 Meses</option>
         <option>6 - 12 Meses</option>
         <option>Mayor a 12 Meses</option>
@@ -193,7 +193,7 @@
 
     <div>
       <label class="block font-semibold text-gray-700">ENTIDAD</label>
-      <select class="w-full border border-gray-300 p-2 rounded">
+      <select id="filtro-entidad" class="w-full border border-gray-300 p-2 rounded">
         <option>Avaluo Banco agrario</option>
         <option>Avaluo SAE</option>
         <option>Oferta</option>
@@ -202,7 +202,7 @@
 
     <div>
       <label class="block font-semibold text-gray-700">Tipo de Inmueble</label>
-      <select class="w-full border border-gray-300 p-2 rounded">
+      <select id="filtro-tipo" class="w-full border border-gray-300 p-2 rounded">
         <option>Casa</option>
         <option>Apartamento</option>
         <option>Oficina</option>
@@ -213,22 +213,22 @@
     <div>
       <label class="block font-semibold text-gray-700">Precio m² (COP)</label>
       <div class="flex gap-2">
-        <input type="number" placeholder="Desde" class="w-1/2 border p-2 rounded"/>
-        <input type="number" placeholder="Hasta" class="w-1/2 border p-2 rounded"/>
+        <input id="precio-min" type="number" placeholder="Desde" class="w-1/2 border p-2 rounded"/>
+        <input id="precio-max" type="number" placeholder="Hasta" class="w-1/2 border p-2 rounded"/>
       </div>
     </div>
 
     <div>
       <label class="block font-semibold text-gray-700">Área m²</label>
       <div class="flex gap-2">
-        <input type="number" placeholder="Mín" class="w-1/2 border p-2 rounded"/>
-        <input type="number" placeholder="Máx" class="w-1/2 border p-2 rounded"/>
+        <input id="area-min" type="number" placeholder="Mín" class="w-1/2 border p-2 rounded"/>
+        <input id="area-max" type="number" placeholder="Máx" class="w-1/2 border p-2 rounded"/>
       </div>
     </div>
 
     <div>
       <label class="block font-semibold text-gray-700">Estrato</label>
-      <select class="w-full border border-gray-300 p-2 rounded">
+      <select id="filtro-estrato" class="w-full border border-gray-300 p-2 rounded">
         <option>Todos</option>
         <option>1</option>
         <option>2</option>
@@ -420,6 +420,7 @@
     };
     // Crear y exponer la capa de ofertas
     window.ofertasLayer = L.featureGroup().addTo(map);
+    window.ofertaLayers = []; // almacenará todas las capas individuales
     // Definir EPSG:3116 antes de usar proj4()
     proj4.defs("EPSG:3116",
       "+proj=tmerc +lat_0=4.5962004166667 +lon_0=-74.077507916667 " +
@@ -431,6 +432,7 @@
       .then(ofertas => {
         // Limpiar capa antes de recargar
         ofertasLayer.clearLayers();
+        window.ofertaLayers = [];
 
         ofertas.forEach(oferta => {
           // Polígonos (KML/KMZ/ZIP → GeoJSON)
@@ -451,8 +453,9 @@
                       geometry: feature.geometry,
                       properties: oferta
                     };
-                    // Añadir a la capa de ofertas
+                    // Añadir a la capa de ofertas y registrar
                     ofertasLayer.addLayer(lyr);
+                    window.ofertaLayers.push({ layer: lyr, properties: oferta });
                   }
                 });
               })
@@ -470,17 +473,14 @@
                   className: 'tooltip-id'
                 }
               );
-            marker.feature = { /* … */ };
-            ofertasLayer.addLayer(marker);
 
-            // Asignar feature para cálculos
             marker.feature = {
               geometry: { type: 'Point', coordinates: [oferta.Longitud, oferta.Latitud] },
               properties: oferta
             };
 
-            // Añadir a la capa de ofertas
             ofertasLayer.addLayer(marker);
+            window.ofertaLayers.push({ layer: marker, properties: oferta });
           }
         });
 
@@ -779,6 +779,7 @@
   });
 </script>
 <script src="normas.js"></script>
+<script src="filtros.js" defer></script>
 <script src="calculosmercado.js" defer></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 <script src="exportMap.js" defer></script>


### PR DESCRIPTION
## Summary
- wire up filters in sidebar to show/hide offers on map
- expose `updateSidebarStats` for cross-script use
- add `filtros.js` to handle filtering logic

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6886a9441e848325afb2b684ac11245e