### PR TITLE
Render polygons whenever geometry exists

### DIFF
--- a/index.html
+++ b/index.html
@@ -437,7 +437,7 @@
 
         ofertas.forEach(oferta => {
           // Polígonos (KML/KMZ/ZIP → GeoJSON)
-          if (oferta.poligono && oferta.Latitud == null) {
+          if (oferta.poligono) {
             const url = oferta.poligono;
             const ext = url.split('.').pop().toLowerCase();
 


### PR DESCRIPTION
## Summary
- Remove Latitud-null check so polygon geometries display whenever provided

## Testing
- `npm test` (fails: Error: no test specified)
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_6893765344848325b8d1cf915a2a9d0a