### PR TITLE
feat: highlight selected offers

### DIFF
--- a/calculosmercado.js
+++ b/calculosmercado.js
@@ -32,6 +32,21 @@ window.addEventListener('DOMContentLoaded', () => {
     // 3) Estado de checkboxes
     const selectedIds = new Set();
 
+    // Cambia el estilo del icono o polígono según si está seleccionado
+    function setOfferHighlight(id, highlight) {
+      const entry = window.ofertaLayers.find(o => o.properties.ID === id);
+      if (!entry) return;
+      const layer = entry.layer;
+      if (typeof layer.setIcon === 'function') {
+        layer.setIcon(highlight ? window.selectedIcon : window.defaultIcon);
+      } else if (typeof layer.setStyle === 'function') {
+        layer.setStyle({
+          color: highlight ? 'green' : '#3388ff',
+          fillColor: highlight ? 'green' : '#3388ff'
+        });
+      }
+    }
+
     // 4) Render checklist
     function renderChecklist(visible) {
       console.log('renderChecklist → visible IDs:', visible.map(o => o.id));
@@ -43,22 +58,24 @@ window.addEventListener('DOMContentLoaded', () => {
         const chk = document.createElement('input');
         chk.type = 'checkbox';
         chk.value = o.id; chk.id = `offer-${o.id}`;
-        chk.classList.add('h-4','w-4','text-green-600','border-gray-300','rounded');
-        if (selectedIds.has(o.id)) chk.checked = true;
-        chk.addEventListener('change', e => {
-          if (e.target.checked) selectedIds.add(o.id);
-          else selectedIds.delete(o.id);
-          console.log('Checkbox change → selectedIds now:', Array.from(selectedIds));
-          updateSidebarStats();
+          chk.classList.add('h-4','w-4','text-green-600','border-gray-300','rounded');
+          if (selectedIds.has(o.id)) chk.checked = true;
+          chk.addEventListener('change', e => {
+            if (e.target.checked) selectedIds.add(o.id);
+            else selectedIds.delete(o.id);
+            console.log('Checkbox change → selectedIds now:', Array.from(selectedIds));
+            setOfferHighlight(o.id, e.target.checked);
+            updateSidebarStats();
+          });
+          const label = document.createElement('label');
+          label.htmlFor = chk.id;
+          label.classList.add('ml-2','text-sm','text-gray-700');
+          label.textContent = `Oferta #${o.id}`;
+          wrapper.append(chk, label);
+          container.appendChild(wrapper);
+          setOfferHighlight(o.id, selectedIds.has(o.id));
         });
-        const label = document.createElement('label');
-        label.htmlFor = chk.id;
-        label.classList.add('ml-2','text-sm','text-gray-700');
-        label.textContent = `Oferta #${o.id}`;
-        wrapper.append(chk, label);
-        container.appendChild(wrapper);
-      });
-    }
+      }
 
     // 5) Función principal: filtrar, calcular y actualizar DOM
 // 4) Función principal: filtrar, calcular y actualizar DOM

--- a/index.html
+++ b/index.html
@@ -439,14 +439,35 @@ L.control.layers(baseLayers, null, { position: 'bottomleft' }).addTo(map);
       const num = Number(v) || 0;
       return num.toLocaleString('es-CO');
     };
-    // Crear y exponer la capa de ofertas
-    window.ofertasLayer = L.featureGroup().addTo(map);
-    window.ofertaLayers = []; // almacenará todas las capas individuales
-    // Definir EPSG:3116 antes de usar proj4()
-    proj4.defs("EPSG:3116",
-      "+proj=tmerc +lat_0=4.5962004166667 +lon_0=-74.077507916667 " +
-      "+k=1 +x_0=1000000 +y_0=1000000 +ellps=GRS80 +units=m +no_defs"
-    );
+      // Crear y exponer la capa de ofertas
+      window.ofertasLayer = L.featureGroup().addTo(map);
+      window.ofertaLayers = []; // almacenará todas las capas individuales
+      // Iconos para marcar selección de ofertas
+      window.defaultIcon = L.icon({
+        iconUrl: 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-blue.png',
+        iconRetinaUrl: 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-2x-blue.png',
+        shadowUrl: 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-shadow.png',
+        iconSize: [25, 41],
+        iconAnchor: [12, 41],
+        popupAnchor: [1, -34],
+        tooltipAnchor: [16, -28],
+        shadowSize: [41, 41]
+      });
+      window.selectedIcon = L.icon({
+        iconUrl: 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-green.png',
+        iconRetinaUrl: 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-2x-green.png',
+        shadowUrl: 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-shadow.png',
+        iconSize: [25, 41],
+        iconAnchor: [12, 41],
+        popupAnchor: [1, -34],
+        tooltipAnchor: [16, -28],
+        shadowSize: [41, 41]
+      });
+      // Definir EPSG:3116 antes de usar proj4()
+      proj4.defs("EPSG:3116",
+        "+proj=tmerc +lat_0=4.5962004166667 +lon_0=-74.077507916667 " +
+        "+k=1 +x_0=1000000 +y_0=1000000 +ellps=GRS80 +units=m +no_defs"
+      );
 
     /**
      * Renderiza un polígono en el mapa a partir de un archivo remoto.
@@ -495,9 +516,9 @@ L.control.layers(baseLayers, null, { position: 'bottomleft' }).addTo(map);
           if (oferta.poligono) {
             renderPoligono(oferta.poligono, oferta, ofertasLayer);
 
-          // Puntos (Latitud/Longitud)
-          } else if (oferta.Latitud != null && oferta.Longitud != null) {
-            const marker = L.marker([oferta.Latitud, oferta.Longitud])
+            // Puntos (Latitud/Longitud)
+            } else if (oferta.Latitud != null && oferta.Longitud != null) {
+            const marker = L.marker([oferta.Latitud, oferta.Longitud], { icon: window.defaultIcon })
               .bindPopup(generarPopupHTML(oferta))
               .bindTooltip(
                 `ID: ${oferta.ID}`, {
@@ -588,7 +609,7 @@ L.control.layers(baseLayers, null, { position: 'bottomleft' }).addTo(map);
             map.fitBounds(layer.getBounds());
           });
         } else if (oferta.Latitud != null) {
-          const marker = L.marker([oferta.Latitud, oferta.Longitud])
+          const marker = L.marker([oferta.Latitud, oferta.Longitud], { icon: window.defaultIcon })
             .bindPopup(generarPopupHTML(oferta))
             .bindTooltip(
               `ID: ${oferta.ID}`, {


### PR DESCRIPTION
## Summary
- add green and blue Leaflet icons for offers
- toggle marker or polygon styles when users select offers in sidebar

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_689e4b474b408325b09707a30d2ee5b0