### PR TITLE
feat: highlight selected offers

### DIFF
--- a/calculosmercado.js
+++ b/calculosmercado.js
@@ -32,6 +32,23 @@ window.addEventListener('DOMContentLoaded', () => {
     // 3) Estado de checkboxes
     const selectedIds = new Set();
 
+    // Cambia el estilo del icono o polígono según si está seleccionado
+    function setOfferHighlight(id, highlight) {
+      const entry = window.ofertaLayers.find(
+        o => String(o.properties.ID) === String(id)
+      );
+      if (!entry) return;
+      const layer = entry.layer;
+      if (typeof layer.setIcon === 'function') {
+        layer.setIcon(highlight ? window.selectedIcon : window.defaultIcon);
+      } else if (typeof layer.setStyle === 'function') {
+        layer.setStyle({
+          color: highlight ? 'green' : '#3388ff',
+          fillColor: highlight ? 'green' : '#3388ff'
+        });
+      }
+    }
+
     // 4) Render checklist
     function renderChecklist(visible) {
       console.log('renderChecklist → visible IDs:', visible.map(o => o.id));
@@ -39,122 +56,128 @@ window.addEventListener('DOMContentLoaded', () => {
       container.innerHTML = '';
       visible.forEach(o => {
         const wrapper = document.createElement('div');
-        wrapper.classList.add('flex','items-center','mb-1');
+        wrapper.classList.add('flex', 'items-center', 'mb-1');
+
         const chk = document.createElement('input');
         chk.type = 'checkbox';
-        chk.value = o.id; chk.id = `offer-${o.id}`;
-        chk.classList.add('h-4','w-4','text-green-600','border-gray-300','rounded');
+        chk.value = o.id;
+        chk.id = `offer-${o.id}`;
+        chk.classList.add('h-4', 'w-4', 'text-green-600', 'border-gray-300', 'rounded');
         if (selectedIds.has(o.id)) chk.checked = true;
+
         chk.addEventListener('change', e => {
           if (e.target.checked) selectedIds.add(o.id);
           else selectedIds.delete(o.id);
           console.log('Checkbox change → selectedIds now:', Array.from(selectedIds));
+          setOfferHighlight(o.id, e.target.checked);
           updateSidebarStats();
         });
+
         const label = document.createElement('label');
         label.htmlFor = chk.id;
-        label.classList.add('ml-2','text-sm','text-gray-700');
+        label.classList.add('ml-2', 'text-sm', 'text-gray-700');
         label.textContent = `Oferta #${o.id}`;
         wrapper.append(chk, label);
         container.appendChild(wrapper);
+
+        setOfferHighlight(o.id, selectedIds.has(o.id));
       });
     }
 
     // 5) Función principal: filtrar, calcular y actualizar DOM
-// 4) Función principal: filtrar, calcular y actualizar DOM
-function updateSidebarStats() {
-  console.group('▶️ updateSidebarStats');
+    function updateSidebarStats() {
+      console.group('▶️ updateSidebarStats');
 
-  // 1) Repoblar allOffers
-  populateOffers();
+      // 1) Repoblar allOffers
+      populateOffers();
 
-  // 2) Ofertas en la vista actual
-  const bounds  = map.getBounds();
-  const visible = allOffers.filter(o => {
-    const [lon, lat] = o.geometry.coordinates;
-    return bounds.contains([lat, lon]);
-  });
+      // 2) Ofertas en la vista actual
+      const bounds  = map.getBounds();
+      const visible = allOffers.filter(o => {
+        const [lon, lat] = o.geometry.coordinates;
+        return bounds.contains([lat, lon]);
+      });
 
-  // 2.1) Mostrar checklist
-  renderChecklist(visible);
+      // 2.1) Mostrar checklist
+      renderChecklist(visible);
 
-  // 3) Subconjunto (seleccionadas o todas visibles)
-  const subset = selectedIds.size > 0
-    ? visible.filter(o => selectedIds.has(o.id))
-    : visible;
+      // 3) Subconjunto (seleccionadas o todas visibles)
+      const subset = selectedIds.size > 0
+        ? visible.filter(o => selectedIds.has(o.id))
+        : visible;
 
-  // 3.1) Actualizar total
-  document.getElementById('stat-total').textContent =
-    subset.length;
+      // 3.1) Actualizar total
+      document.getElementById('stat-total').textContent =
+        subset.length;
 
-  // 4) Extraer valores unitarios
-  const unitValues = subset
-    .map(o => parseFloat(o.properties['Valor por unidad (COP)']) || 0)
-    .filter(v => v > 0);
+      // 4) Extraer valores unitarios
+      const unitValues = subset
+        .map(o => parseFloat(o.properties['Valor por unidad (COP)']) || 0)
+        .filter(v => v > 0);
 
-  // 5) Calcular estadísticos
-  let avg = 0, std = 0, cv = 0, low = 0, high = 0, adopted = 0;
-  const n = unitValues.length;
-  if (n > 0) {
-    avg = unitValues.reduce((a,b) => a + b, 0) / n;
-    if (n > 1) {
-      const varSum = unitValues
-        .map(v => (v - avg) ** 2)
-        .reduce((a,b) => a + b, 0) / (n - 1);
-      std  = Math.sqrt(varSum);
-      cv   = avg ? std / avg : 0;
-      low  = avg - std;
-      high = avg + std;
+      // 5) Calcular estadísticos
+      let avg = 0, std = 0, cv = 0, low = 0, high = 0, adopted = 0;
+      const n = unitValues.length;
+      if (n > 0) {
+        avg = unitValues.reduce((a,b) => a + b, 0) / n;
+        if (n > 1) {
+          const varSum = unitValues
+            .map(v => (v - avg) ** 2)
+            .reduce((a,b) => a + b, 0) / (n - 1);
+          std  = Math.sqrt(varSum);
+          cv   = avg ? std / avg : 0;
+          low  = avg - std;
+          high = avg + std;
+        }
+        adopted = Math.round(avg / 10000) * 10000;
+      }
+
+      // 6) Pintar los nuevos estadísticos
+      const elems = {
+        stdUnit:     document.getElementById('stat-std-unit'),
+        cvUnit:      document.getElementById('stat-cv-unit'),
+        lowUnit:     document.getElementById('stat-low-unit'),
+        highUnit:    document.getElementById('stat-high-unit'),
+        avgUnit:     document.getElementById('stat-prom'),
+        adoptedSel:  document.getElementById('select-adopted-unit'),
+        adoptedP:    document.getElementById('stat-adopted-unit')
+      };
+
+      elems.stdUnit  .textContent = n ? Math.round(std).toLocaleString('es-CO')        : '—';
+      elems.cvUnit   .textContent = n ? `${(cv*100).toFixed(2)}%`                        : '—';
+      elems.lowUnit  .textContent = n ? `$${Math.round(low).toLocaleString('es-CO')}`    : '—';
+      elems.highUnit .textContent = n ? `$${Math.round(high).toLocaleString('es-CO')}`   : '—';
+      elems.avgUnit  .textContent = n ? `$${Math.round(avg).toLocaleString('es-CO')}`    : '—';
+
+      // 7) Rellenar <select> de Valor Adoptado
+      if (elems.adoptedSel) {
+        elems.adoptedSel.innerHTML = n > 0 ? `
+          <option value="${low}">Inferior: $${Math.round(low).toLocaleString('es-CO')}</option>
+          <option value="${avg}">Promedio: $${Math.round(avg).toLocaleString('es-CO')}</option>
+          <option value="${high}">Superior: $${Math.round(high).toLocaleString('es-CO')}</option>
+        ` : `<option disabled selected>—</option>`;
+
+        // Por defecto, seleccionamos “Promedio”
+        elems.adoptedSel.value = String(avg);
+
+        // Pintar también el <p> de stat-adopted-unit
+        elems.adoptedP.textContent = avg
+          ? `$${Math.round(avg).toLocaleString('es-CO')}`
+          : '—';
+
+        // Y si el usuario cambia la opción, actualizamos ese <p>
+        elems.adoptedSel.onchange = () => {
+          const v = parseFloat(elems.adoptedSel.value);
+          elems.adoptedP.textContent = v
+            ? `$${Math.round(v).toLocaleString('es-CO')}`
+            : '—';
+        };
+      }
+
+      console.groupEnd();
+      // Exponer para que otros scripts actualicen los cálculos
+      window.updateSidebarStats = updateSidebarStats;
     }
-    adopted = Math.round(avg / 10000) * 10000;
-  }
-
-  // 6) Pintar los nuevos estadísticos
-  const elems = {
-    stdUnit:     document.getElementById('stat-std-unit'),
-    cvUnit:      document.getElementById('stat-cv-unit'),
-    lowUnit:     document.getElementById('stat-low-unit'),
-    highUnit:    document.getElementById('stat-high-unit'),
-    avgUnit:     document.getElementById('stat-prom'),
-    adoptedSel:  document.getElementById('select-adopted-unit'),
-    adoptedP:    document.getElementById('stat-adopted-unit')
-  };
-
-  elems.stdUnit  .textContent = n ? Math.round(std).toLocaleString('es-CO')        : '—';
-  elems.cvUnit   .textContent = n ? `${(cv*100).toFixed(2)}%`                        : '—';
-  elems.lowUnit  .textContent = n ? `$${Math.round(low).toLocaleString('es-CO')}`    : '—';
-  elems.highUnit .textContent = n ? `$${Math.round(high).toLocaleString('es-CO')}`   : '—';
-  elems.avgUnit  .textContent = n ? `$${Math.round(avg).toLocaleString('es-CO')}`    : '—';
-
-  // 7) Rellenar <select> de Valor Adoptado
-  if (elems.adoptedSel) {
-    elems.adoptedSel.innerHTML = n > 0 ? `
-      <option value="${low}">Inferior: $${Math.round(low).toLocaleString('es-CO')}</option>
-      <option value="${avg}">Promedio: $${Math.round(avg).toLocaleString('es-CO')}</option>
-      <option value="${high}">Superior: $${Math.round(high).toLocaleString('es-CO')}</option>
-    ` : `<option disabled selected>—</option>`;
-
-    // Por defecto, seleccionamos “Promedio”
-    elems.adoptedSel.value = String(avg);
-
-    // Pintar también el <p> de stat-adopted-unit
-    elems.adoptedP.textContent = avg
-      ? `$${Math.round(avg).toLocaleString('es-CO')}`
-      : '—';
-
-    // Y si el usuario cambia la opción, actualizamos ese <p>
-    elems.adoptedSel.onchange = () => {
-      const v = parseFloat(elems.adoptedSel.value);
-      elems.adoptedP.textContent = v
-        ? `$${Math.round(v).toLocaleString('es-CO')}`
-        : '—';
-    };
-  }
-
-  console.groupEnd();
-  // Exponer para que otros scripts actualicen los cálculos
-  window.updateSidebarStats = updateSidebarStats;
-}
 
     // 6) enganchar eventos
     map.on('moveend zoomend', updateSidebarStats);

--- a/index.html
+++ b/index.html
@@ -439,14 +439,35 @@ L.control.layers(baseLayers, null, { position: 'bottomleft' }).addTo(map);
       const num = Number(v) || 0;
       return num.toLocaleString('es-CO');
     };
-    // Crear y exponer la capa de ofertas
-    window.ofertasLayer = L.featureGroup().addTo(map);
-    window.ofertaLayers = []; // almacenará todas las capas individuales
-    // Definir EPSG:3116 antes de usar proj4()
-    proj4.defs("EPSG:3116",
-      "+proj=tmerc +lat_0=4.5962004166667 +lon_0=-74.077507916667 " +
-      "+k=1 +x_0=1000000 +y_0=1000000 +ellps=GRS80 +units=m +no_defs"
-    );
+      // Crear y exponer la capa de ofertas
+      window.ofertasLayer = L.featureGroup().addTo(map);
+      window.ofertaLayers = []; // almacenará todas las capas individuales
+      // Iconos para marcar selección de ofertas
+      window.defaultIcon = L.icon({
+        iconUrl: 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-blue.png',
+        iconRetinaUrl: 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-2x-blue.png',
+        shadowUrl: 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-shadow.png',
+        iconSize: [25, 41],
+        iconAnchor: [12, 41],
+        popupAnchor: [1, -34],
+        tooltipAnchor: [16, -28],
+        shadowSize: [41, 41]
+      });
+      window.selectedIcon = L.icon({
+        iconUrl: 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-green.png',
+        iconRetinaUrl: 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-2x-green.png',
+        shadowUrl: 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-shadow.png',
+        iconSize: [25, 41],
+        iconAnchor: [12, 41],
+        popupAnchor: [1, -34],
+        tooltipAnchor: [16, -28],
+        shadowSize: [41, 41]
+      });
+      // Definir EPSG:3116 antes de usar proj4()
+      proj4.defs("EPSG:3116",
+        "+proj=tmerc +lat_0=4.5962004166667 +lon_0=-74.077507916667 " +
+        "+k=1 +x_0=1000000 +y_0=1000000 +ellps=GRS80 +units=m +no_defs"
+      );
 
     /**
      * Renderiza un polígono en el mapa a partir de un archivo remoto.
@@ -495,9 +516,9 @@ L.control.layers(baseLayers, null, { position: 'bottomleft' }).addTo(map);
           if (oferta.poligono) {
             renderPoligono(oferta.poligono, oferta, ofertasLayer);
 
-          // Puntos (Latitud/Longitud)
-          } else if (oferta.Latitud != null && oferta.Longitud != null) {
-            const marker = L.marker([oferta.Latitud, oferta.Longitud])
+            // Puntos (Latitud/Longitud)
+            } else if (oferta.Latitud != null && oferta.Longitud != null) {
+            const marker = L.marker([oferta.Latitud, oferta.Longitud], { icon: window.defaultIcon })
               .bindPopup(generarPopupHTML(oferta))
               .bindTooltip(
                 `ID: ${oferta.ID}`, {
@@ -517,6 +538,8 @@ L.control.layers(baseLayers, null, { position: 'bottomleft' }).addTo(map);
             window.ofertaLayers.push({ layer: marker, properties: oferta });
           }
         });
+
+        window.updateSidebarStats?.();
 
       })
       .catch(err => console.error('Error cargando ofertas:', err));
@@ -588,7 +611,7 @@ L.control.layers(baseLayers, null, { position: 'bottomleft' }).addTo(map);
             map.fitBounds(layer.getBounds());
           });
         } else if (oferta.Latitud != null) {
-          const marker = L.marker([oferta.Latitud, oferta.Longitud])
+          const marker = L.marker([oferta.Latitud, oferta.Longitud], { icon: window.defaultIcon })
             .bindPopup(generarPopupHTML(oferta))
             .bindTooltip(
               `ID: ${oferta.ID}`, {


### PR DESCRIPTION
## Summary
- add green and blue Leaflet icons for offers
- toggle marker or polygon styles when users select offers in sidebar
- refresh stats and icons after loading offers to ensure highlighting works

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_689e4b474b408325b09707a30d2ee5b0